### PR TITLE
https://github.com/grails-plugins/grails-spring-security-oauth2-provi…

### DIFF
--- a/spring-security-oauth2-provider/src/main/templates/OAuth2Client.groovy.template
+++ b/spring-security-oauth2-provider/src/main/templates/OAuth2Client.groovy.template
@@ -58,4 +58,8 @@ class ${OAuth2ClientClassName} {
         clientSecret = clientSecret ?: NO_CLIENT_SECRET
         clientSecret = springSecurityService?.passwordEncoder ? springSecurityService.encodePassword(clientSecret) : clientSecret
     }
+
+    static mapping = {
+        autowire true
+    }
 }


### PR DESCRIPTION
[/issues/18](https://github.com/grails-plugins/grails-spring-security-oauth2-provider/issues/18)

the latest GORM has disabled the autowiring of domain classes (like my generated Client class). The simple solution is to override that default behavior by adding:
```

static mapping = {
   autowire true
}
```